### PR TITLE
Rework for metrics and changes in the warnings for `vars_combinations`

### DIFF
--- a/R/clustering.R
+++ b/R/clustering.R
@@ -100,6 +100,13 @@ clustInd_hierarch <- function(ind_data, vars_combinations,
     stop("input 'vars_combinations' must be a list.", call. = FALSE)
   }
 
+  # Check for correct vars combinations
+  vars_combinations_to_remove <- check_vars_combinations(vars_combinations, ind_data)
+
+  if (length(vars_combinations_to_remove)) {
+    vars_combinations <- vars_combinations[-vars_combinations_to_remove]
+  }
+
   # Check if indices, methods and distances lists are provided
   if (!is.character(method_list) ||
       !is.character(dist_list) || length(vars_combinations) == 0 ||
@@ -265,6 +272,13 @@ clustInd_kmeans <- function(ind_data, vars_combinations,
     stop("Input 'vars_combinations' must be a list.", call. = FALSE)
   }
 
+  # Check for correct vars combinations
+  vars_combinations_to_remove <- check_vars_combinations(vars_combinations, ind_data)
+
+  if (length(vars_combinations_to_remove)) {
+    vars_combinations <- vars_combinations[-vars_combinations_to_remove]
+  }
+
   # Check if indices, methods and distances lists are provided
   if (length(vars_combinations) == 0 || length(dist_list) == 0) {
     stop("Invalid 'vars_combinations' or 'dist_list'. Both must be non-empty
@@ -391,6 +405,13 @@ clustInd_kkmeans <- function(ind_data, vars_combinations,
     stop("Input 'vars_combinations' must be a list.", call. = FALSE)
   }
 
+  # Check for correct vars combinations
+  vars_combinations_to_remove <- check_vars_combinations(vars_combinations, ind_data)
+
+  if (length(vars_combinations_to_remove)) {
+    vars_combinations <- vars_combinations[-vars_combinations_to_remove]
+  }
+
   # Check if indices, and kernel lists are provided
   if (!is.character(kernel_list) || length(vars_combinations) == 0 || length(kernel_list) == 0) {
     stop("Invalid 'kernel_list' or 'vars_combinations'. Both must be non-empty
@@ -511,6 +532,13 @@ clustInd_spc <- function(ind_data, vars_combinations,
 
   if(!is.list(vars_combinations)) {
     stop("Input 'vars_combinations' must be a data frame.", call. = FALSE)
+  }
+
+  # Check for correct vars combinations
+  vars_combinations_to_remove <- check_vars_combinations(vars_combinations, ind_data)
+
+  if (length(vars_combinations_to_remove)) {
+    vars_combinations <- vars_combinations[-vars_combinations_to_remove]
   }
 
   # Check if indices, methods and distances lists are provided

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -70,9 +70,6 @@ clustInd_hierarch_aux <- function(ind_data, vars, method = "single",
 #' @param n_cluster number of clusters to generate.
 #' @param true_labels Vector of true labels for validation
 #' (if it is not known true_labels is set to NULL)
-#' @param colapse It is a boolean. If it is true a dataframe with metrics values
-#' is generated. If \code{true_labels} is True the dataframe contains Purity,
-#' F-measure, RI and Time, and if it is False, only Time.
 #' @param num_cores Number of cores to do parallel computation. 1 by default,
 #' which mean no parallel execution.
 #' @return A list containing hierarchical clustering results
@@ -88,7 +85,7 @@ clustInd_hierarch <- function(ind_data, vars_combinations,
                               method_list = c("single","complete","average",
                                               "centroid","ward.D2"),
                               dist_list = c("euclidean", "manhattan"),
-                              n_cluster=2, true_labels = NULL, colapse = FALSE,
+                              n_cluster=2, true_labels = NULL,
                               num_cores=1) {
 
   # Check if input is a data frame
@@ -136,12 +133,6 @@ clustInd_hierarch <- function(ind_data, vars_combinations,
 
   result_name <- get_result_names("hierarch", parameter_combinations, vars_combinations)
   names(result) <- result_name
-
-  if (colapse) {
-    result <- list("list" = result,
-                   "metrics" = result_to_table(result, colapse))
-  }
-
 
   return(result)
 }
@@ -242,9 +233,6 @@ clustInd_kmeans_aux <- function(ind_data, vars, dist = "euclidean",
 #' @param n_cluster Number of clusters to create
 #' @param true_labels Vector of true labels for validation
 #' (if it is not known true_labels is set to NULL)
-#' @param colapse It is a boolean. If it is true a dataframe with metrics values
-#' is generated. If \code{true_labels} is True the dataframe contains Purity,
-#' F-measure, RI and Time, and if it is False, only Time.
 #' @param num_cores Number of cores to do parallel computation. 1 by default,
 #' which mean no parallel execution.
 #' @return A list containing hierarchical clustering results
@@ -260,7 +248,7 @@ clustInd_kmeans_aux <- function(ind_data, vars, dist = "euclidean",
 #' clustInd_kmeans(data_ind, list(vars1, vars2))
 clustInd_kmeans <- function(ind_data, vars_combinations,
                             dist_list = c("euclidean", "mahalanobis"),
-                            n_cluster = 2, true_labels = NULL, colapse = FALSE,
+                            n_cluster = 2, true_labels = NULL,
                             num_cores = 1) {
 
   # Check if input is a data frame
@@ -307,11 +295,6 @@ clustInd_kmeans <- function(ind_data, vars_combinations,
 
   result_name <- get_result_names("kmeans", parameter_combinations, vars_combinations)
   names(result) <- result_name
-
-  if (colapse) {
-    result <- list("list" = result,
-                   "metrics" = result_to_table(result, colapse))
-  }
 
   return(result)
 }
@@ -376,9 +359,6 @@ clustInd_kkmeans_aux <- function(ind_data, vars, kernel = "rbfdot",
 #' @param n_cluster Number of clusters to create
 #' @param true_labels Vector of true labels for validation
 #' (if it is not known true_labels is set to NULL)
-#' @param colapse It is a boolean. If it is true a dataframe with metrics values
-#' is generated. If \code{true_labels} is True the dataframe contains Purity,
-#' F-measure, RI and Time, and if it is False, only Time.
 #' @param num_cores Number of cores to do parallel computation. 1 by default,
 #' which mean no parallel execution.
 #' @param ... Additional arguments (unused)
@@ -393,7 +373,7 @@ clustInd_kkmeans_aux <- function(ind_data, vars, kernel = "rbfdot",
 #' clustInd_kkmeans(data_ind, list(vars1, vars2))
 clustInd_kkmeans <- function(ind_data, vars_combinations,
                              kernel_list = c("rbfdot", "polydot"),
-                             n_cluster = 2, true_labels = NULL, colapse = FALSE,
+                             n_cluster = 2, true_labels = NULL,
                              num_cores = 1, ...) {
 
   # Check if input is a data frame
@@ -439,11 +419,6 @@ clustInd_kkmeans <- function(ind_data, vars_combinations,
 
   result_name <- get_result_names("kkmeans", parameter_combinations, vars_combinations)
   names(result) <- result_name
-
-  if (colapse) {
-    result <- list("list" = result,
-                   "metrics" = result_to_table(result, colapse))
-  }
 
   return(result)
 }
@@ -505,9 +480,6 @@ clustInd_spc_aux <- function(ind_data, vars, kernel = "rbfdot", n_cluster = 2,
 #' @param n_cluster Number of clusters to create
 #' @param true_labels Vector of true labels for validation
 #' (if it is not known true_labels is set to NULL)
-#' @param colapse It is a boolean. If it is true a dataframe with metrics values
-#' is generated. If \code{true_labels} is True the dataframe contains Purity,
-#' F-measure, RI and Time, and if it is False, only Time.
 #' @param num_cores Number of cores to do parallel computation. 1 by default,
 #' which mean no parallel execution.
 #' @param ... Additional arguments (unused)
@@ -522,7 +494,7 @@ clustInd_spc_aux <- function(ind_data, vars, kernel = "rbfdot", n_cluster = 2,
 #' clustInd_spc(data_ind, list(vars1, vars2))
 clustInd_spc <- function(ind_data, vars_combinations,
                          kernel_list = c("rbfdot", "polydot"),
-                         n_cluster = 2, true_labels = NULL, colapse = FALSE,
+                         n_cluster = 2, true_labels = NULL,
                          num_cores = 1, ...) {
 
   # Check if input is a data frame
@@ -569,9 +541,6 @@ clustInd_spc <- function(ind_data, vars_combinations,
 
   result_name <- get_result_names("spc", parameter_combinations, vars_combinations)
   names(result) <- result_name
-
-  if(colapse) result <- list("list" = result,
-                             "metrics" = result_to_table(result, colapse))
 
   return(result)
 }

--- a/R/simulation_models.R
+++ b/R/simulation_models.R
@@ -53,6 +53,7 @@ sim_model_ex1 <- function(n = 50, p = 30, i_sim = 1, seed = NULL){
   if(!is.null(seed)) {
     old <- .Random.seed
     on.exit({.Random.seed <<- old})
+    set.seed(seed)
   }
 
   t_interval <- seq(0, 1, length = p)
@@ -122,6 +123,7 @@ sim_model_ex2 <- function(n = 50, p = 150, i_sim = 1, seed = NULL){
   if(!is.null(seed)) {
     old <- .Random.seed
     on.exit({.Random.seed <<- old})
+    set.seed(seed)
   }
 
   t_interval <- seq(0, 1, length = p)

--- a/R/utils.R
+++ b/R/utils.R
@@ -63,31 +63,6 @@ funspline <- function(curves, nbasis, norder, grid_ll = 0, grid_ul = 1, ...) {
   return(res)
 }
 
-#' Transform metrics results from clustering functions in cluster.R to a dataframe
-#'
-#' @param res list containing clustering partition and metric for different
-#' combinations
-#' @param tl_null a bool to indicate weather metrics other than time ane or not
-#' available
-#'
-#' @return Dataframe
-#' @noRd
-result_to_table <- function(res, tl_null){
-  name_res <- names(res)
-  len_res <- length(name_res)
-  if(tl_null){
-      metrics_df <-
-        data.frame(Time = sapply(1:len_res, function (i) res[[i]][[2]]))
-      # row.names(metrics_df) <- name_res
-  } else{
-    metrics_df <-
-      data.frame(t(sapply(1:len_res, function (i) c(res[[i]][[2]],
-                                                    "Time" = res[[i]][[3]]))))
-    # row.names(metrics_df) <- name_res
-    }
-  return(metrics_df)
-}
-
 #' Checks for list function arguments
 #'
 #' Checks that a list given as argument to a function is not empty,

--- a/R/utils.R
+++ b/R/utils.R
@@ -124,11 +124,17 @@ quiet <- function(x) {
 #' @noRd
 check_vars_combinations <- function(vars_combinations, ind_curves) {
   vars_combinations_to_remove <- c()
+
+  vars_empty           <- c()
+  vars_invalid_name    <- c()
+  vars_almost_singular <- c()
+
+
   for (i in seq_along(vars_combinations)) {
     if (length(vars_combinations[[i]]) == 0) {
       vars_combinations_to_remove <- c(vars_combinations_to_remove, i)
-      warning(paste0("Index '", i, "' of 'vars_combinations' is empty.",
-                     "Removing it..."))
+      vars_empty <- c(vars_empty, i)
+
       next
     }
 
@@ -141,21 +147,36 @@ check_vars_combinations <- function(vars_combinations, ind_curves) {
 
     if (!all(vars_combinations[[i]] %in% names(ind_curves))) {
       vars_combinations_to_remove <- c(vars_combinations_to_remove, i)
-      warning(paste0("Invalid variable name in 'vars_combinations' for index ", i,
-                     ". Removing combination..."))
+      vars_invalid_name <- c(vars_invalid_name, i)
 
       next
     }
 
     if (det(stats::var(ind_curves[,vars_combinations[[i]]])) == 0) {
       vars_combinations_to_remove <- c(vars_combinations_to_remove, i)
-
-      warning(paste0("Combination of variables '",
-                     paste0(vars_combinations[i], collapse = ", "),
-                     "' with index ", i, " is singular or almost singular.\n",
-                     "Excluding it from any computation...")
-      )
+      vars_almost_singular <- c(vars_almost_singular, i)
     }
+  }
+
+  if (length(vars_empty)) {
+    warning(paste0("Index/indices '", paste0(vars_empty, collapse = ", "), "' of 'vars_combinations' is/are empty.",
+                   "Removing them..."))
+  }
+
+  if (length(vars_invalid_name)) {
+    warning(paste0("Invalid variable name in 'vars_combinations' for index/indices ",
+                   paste0(vars_invalid_name, collapse = ", "),
+                   ". Removing them..."))
+  }
+
+  if (length(vars_almost_singular)) {
+    warning(paste0("Combination/s of variables with index/indices", paste0(vars_almost_singular, collapse = ", "),
+                   "is/are singular or almost singular. Removing them..."))
+  }
+
+  if (length(vars_combinations_to_remove)) {
+    warning(paste0("Combination/s of variable/s with index", paste0(vars_combinations_to_remove, collapse = ", "),
+                   "are not valid. Excluding them from any computation..."))
   }
 
   if (length(vars_combinations_to_remove) == length(vars_combinations)) {

--- a/man/EHyClus.Rd
+++ b/man/EHyClus.Rd
@@ -34,8 +34,10 @@ The functional dataset can be one dimensional (\eqn{n \times p}) where n is the 
 curves and p the number of time points, or multidimensional (\eqn{n \times p \times k}) where k
 represents the number of dimensions in the data}
 
-\item{vars_combinations}{\code{list} containing one or more combinations of indexes in
-\code{ind_data}. If it is non-named, the names of the variables are set to
+\item{vars_combinations}{\code{list} containing one or more combinations of variables.
+Each element of the list should be an atomic \code{vector} of strings with the
+names of the variables. Combinations with non-valid variable names will be discarded.
+If it is non-named, the names of the variables are set to
 vars1, ..., varsk, where k is the number of elements in \code{vars_combinations}.}
 
 \item{nbasis}{Number of basis for the B-splines.}

--- a/man/EHyClus.Rd
+++ b/man/EHyClus.Rd
@@ -22,7 +22,6 @@ EHyClus(
   grid_ll = 0,
   grid_ul = 1,
   true_labels = NULL,
-  colapse = FALSE,
   verbose = FALSE,
   num_cores = 1,
   ...
@@ -68,10 +67,6 @@ clustering}
 
 \item{true_labels}{Vector of true labels for validation
 (if it is not known true_labels is set to NULL)}
-
-\item{colapse}{It is a boolean. If it is true a dataframe with metrics values
-is generated. If \code{true_labels} is True the dataframe contains Purity,
-F-measure, RI and Time, and if it is False, only Time.}
 
 \item{verbose}{If \code{TRUE}, the function will print logs for about the execution of
 some clustering methods. Defaults to \code{FALSE}.}

--- a/man/clustInd_hierarch.Rd
+++ b/man/clustInd_hierarch.Rd
@@ -12,7 +12,6 @@ clustInd_hierarch(
   dist_list = c("euclidean", "manhattan"),
   n_cluster = 2,
   true_labels = NULL,
-  colapse = FALSE,
   num_cores = 1
 )
 }
@@ -32,10 +31,6 @@ vars1, ..., varsk, where k is the number of elements in \code{vars_combinations}
 
 \item{true_labels}{Vector of true labels for validation
 (if it is not known true_labels is set to NULL)}
-
-\item{colapse}{It is a boolean. If it is true a dataframe with metrics values
-is generated. If \code{true_labels} is True the dataframe contains Purity,
-F-measure, RI and Time, and if it is False, only Time.}
 
 \item{num_cores}{Number of cores to do parallel computation. 1 by default,
 which mean no parallel execution.}

--- a/man/clustInd_kkmeans.Rd
+++ b/man/clustInd_kkmeans.Rd
@@ -11,7 +11,6 @@ clustInd_kkmeans(
   kernel_list = c("rbfdot", "polydot"),
   n_cluster = 2,
   true_labels = NULL,
-  colapse = FALSE,
   num_cores = 1,
   ...
 )
@@ -30,10 +29,6 @@ vars1, ..., varsk, where k is the number of elements in \code{vars_combinations}
 
 \item{true_labels}{Vector of true labels for validation
 (if it is not known true_labels is set to NULL)}
-
-\item{colapse}{It is a boolean. If it is true a dataframe with metrics values
-is generated. If \code{true_labels} is True the dataframe contains Purity,
-F-measure, RI and Time, and if it is False, only Time.}
 
 \item{num_cores}{Number of cores to do parallel computation. 1 by default,
 which mean no parallel execution.}

--- a/man/clustInd_kmeans.Rd
+++ b/man/clustInd_kmeans.Rd
@@ -11,7 +11,6 @@ clustInd_kmeans(
   dist_list = c("euclidean", "mahalanobis"),
   n_cluster = 2,
   true_labels = NULL,
-  colapse = FALSE,
   num_cores = 1
 )
 }
@@ -29,10 +28,6 @@ vars1, ..., varsk, where k is the number of elements in \code{vars_combinations}
 
 \item{true_labels}{Vector of true labels for validation
 (if it is not known true_labels is set to NULL)}
-
-\item{colapse}{It is a boolean. If it is true a dataframe with metrics values
-is generated. If \code{true_labels} is True the dataframe contains Purity,
-F-measure, RI and Time, and if it is False, only Time.}
 
 \item{num_cores}{Number of cores to do parallel computation. 1 by default,
 which mean no parallel execution.}

--- a/man/clustInd_spc.Rd
+++ b/man/clustInd_spc.Rd
@@ -11,7 +11,6 @@ clustInd_spc(
   kernel_list = c("rbfdot", "polydot"),
   n_cluster = 2,
   true_labels = NULL,
-  colapse = FALSE,
   num_cores = 1,
   ...
 )
@@ -30,10 +29,6 @@ vars1, ..., varsk, where k is the number of elements in \code{vars_combinations}
 
 \item{true_labels}{Vector of true labels for validation
 (if it is not known true_labels is set to NULL)}
-
-\item{colapse}{It is a boolean. If it is true a dataframe with metrics values
-is generated. If \code{true_labels} is True the dataframe contains Purity,
-F-measure, RI and Time, and if it is False, only Time.}
 
 \item{num_cores}{Number of cores to do parallel computation. 1 by default,
 which mean no parallel execution.}

--- a/man/ind.Rd
+++ b/man/ind.Rd
@@ -50,4 +50,5 @@ ind(x1, nbasis = 4)
 
 x2 <- matrix(c(1,2,3,3,2,1,5,2,3,9,8,7), nrow = 3, ncol  = 4)
 ind(x2, nbasis = 4)
+
 }

--- a/man/valid.Rd
+++ b/man/valid.Rd
@@ -28,4 +28,5 @@ data_ind <- ehymet::ind(data)
 clus_kmeans <- ehymet::clustInd_kmeans(data_ind, list(vars1))
 cluskmeans_mahalanobis_dtaEIdtaMEI <- clus_kmeans$kmeans_mahalanobis_dtaEIdtaMEI$cluster
 valid(true_labels, cluskmeans_mahalanobis_dtaEIdtaMEI)
+
 }

--- a/tests/testthat/test-EHyClus.R
+++ b/tests/testthat/test-EHyClus.R
@@ -64,3 +64,17 @@ test_that("the checking related to 'vars_combinations' is doing its work", {
 #   )
 # })
 
+test_that("metrics are correctly created when 'true_labels' is given to 'EHyClus'", {
+  n <- 100
+  labels <- rep(c(1,2), each = n)
+
+  vars1  <- c("dtaMEI","ddtaMEI")
+  vars2  <- c("dtaMEI","d2dtaMEI")
+
+  curves <- sim_model_ex1(n = n)
+  res <- EHyClus(curves, list(vars1, vars2), true_labels = labels)
+
+  expect_equal(names(res), c("cluster", "metrics"))
+  expect_equal(dim(res$metrics), c(32, 4))
+})
+


### PR DESCRIPTION
This PR implements only minor changes:

- The `colapse` parameter does not longer exist. Now, if the `true_labels` are given in `EHyClus`, the result will contain the metrics as an element of the list.
- The check for the right `vars_combinations` is now an isolated function. This will not affect the final user.
- The warnings displayed in the checking of the combinations of variables are now more concise.